### PR TITLE
Add $INCLUDE parsing and RFC 2308 $TTL compliance

### DIFF
--- a/t/dns-zoneparse-dollar-ttl.t
+++ b/t/dns-zoneparse-dollar-ttl.t
@@ -16,13 +16,17 @@ sub on_parse_fail {
     }
 }
 
-my $str_zonefile = DNS::ZoneParse->new( \$zone_data, undef, \&on_parse_fail );
+# Specify alternate TTL parsing (using RFC2308 perscribed method of parsing
+# $TTL directives).
+my $alt_ttl_mode = 1;
+
+my $str_zonefile = DNS::ZoneParse->new( \$zone_data, undef, \&on_parse_fail, $alt_ttl_mode );
 ok( $str_zonefile,                                'new obj from string' );
 ok( $str_zonefile->last_parse_error_count() == 0, "caught all errors (none!)" );
 test_zone( $str_zonefile );
 
 my $serialized = $str_zonefile->output();
-$str_zonefile = DNS::ZoneParse->new( \$serialized, undef, \&on_parse_fail );
+$str_zonefile = DNS::ZoneParse->new( \$serialized, undef, \&on_parse_fail, $alt_ttl_mode );
 ok( $str_zonefile,                                'new obj from output' );
 ok( $str_zonefile->last_parse_error_count() == 0, "caught all errors (none!)" );
 test_zone( $str_zonefile );
@@ -40,7 +44,7 @@ sub test_zone {
             'refresh'    => '10801',
             'retry'      => '3600',
             'expire'     => '691200',
-            'ttl'        => '86400',
+            'ttl'        => '3600',
             'primary'    => 'ns0.dns-zoneparse-test.net.',
             'origin'     => '@',
             'email'      => 'support\\.contact.dns-zoneparse-test.net.',
@@ -69,21 +73,21 @@ sub test_zone {
             {
                 'ORIGIN'  => 'dns-zoneparse-test.net.',
                 'class'   => 'IN',
-                'ttl'     => '86400',
+                'ttl'     => '3600',
                 'name'    => '@',
                 'host'    => '127.0.0.1'
             },
             {
                 'ORIGIN'  => 'dns-zoneparse-test.net.',
                 'class'   => 'IN',
-                'ttl'     => '86400',
+                'ttl'     => '3600',
                 'name'    => 'ns1',
                 'host'    => '127.0.0.2'
             },
             {
                 'ORIGIN'  => 'dns-zoneparse-test.net.',
                 'class'   => 'IN',
-                'ttl'     => '10',
+                'ttl'     => '3600',
                 'name'    => 'www',
                 'host'    => '127.0.0.3'
             },
@@ -97,7 +101,7 @@ sub test_zone {
             {
                 'ORIGIN' => 'dns-zoneparse-test.net.',
                 'class'  => 'IN',
-                'ttl'    => '10',
+                'ttl'    => '3600',
                 'name'   => 'ftp',
                 'host'   => 'www'
             },
@@ -109,6 +113,7 @@ sub test_zone {
 
 __DATA__
 $ORIGIN dns-zoneparse-test.net.
+$TTL 3600
 @                           IN	SOA	ns0.dns-zoneparse-test.net.	support\.contact.dns-zoneparse-test.net.	(
                         2000100502   ; serial number
                         10801       ; refresh

--- a/t/dns-zoneparse-exact-soa.t
+++ b/t/dns-zoneparse-exact-soa.t
@@ -63,7 +63,7 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns1.dns-zoneparse-test.net.',

--- a/t/dns-zoneparse-implied-soa.t
+++ b/t/dns-zoneparse-implied-soa.t
@@ -63,7 +63,7 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns1.dns-zoneparse-test.net.',

--- a/t/dns-zoneparse-include.t
+++ b/t/dns-zoneparse-include.t
@@ -74,56 +74,56 @@ sub test_zone {
         $zf->a,
         [
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => '@',
                 'class' => 'IN',
                 'host'  => '127.0.0.1',
                 'ORIGIN' => 'dns-zoneparse-test.net.'
             },
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => 'next-rr-will-have-this-name',
                 'class' => 'IN',
                 'host'  => '127.0.0.1',
                 'ORIGIN' => 'dns-zoneparse-test.net.'
             },
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => '@',
                 'class' => 'IN',
                 'host'  => '127.0.0.2',
                 'ORIGIN' => 'dns-zoneparse-test.net.'
             },
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => 'next-rr-will-have-this-name2',
                 'class' => 'IN',
                 'host'  => '127.0.0.2',
                 'ORIGIN' => 'dns-zoneparse-test.net.'
             },
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => '@',
                 'class' => 'IN',
                 'host'  => '127.0.0.2',
                 'ORIGIN' => 'dns-zoneparse-test-include.net.'
             },
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => 'next-rr-will-have-this-name2',
                 'class' => 'IN',
                 'host'  => '127.0.0.2',
                 'ORIGIN' => 'dns-zoneparse-test-include.net.'
             },
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => '@',
                 'class' => 'IN',
                 'host'  => '127.0.0.2',
                 'ORIGIN' => 'dns-zoneparse-test-include2.net.'
             },
             {
-                'ttl'   => '1H',
+                'ttl'   => '43200',
                 'name'  => 'next-rr-will-have-this-name2',
                 'class' => 'IN',
                 'host'  => '127.0.0.2',
@@ -144,7 +144,7 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns1.dns-zoneparse-test.net.',
@@ -158,7 +158,7 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns3.dns-zoneparse-test.net.',
@@ -172,7 +172,7 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test-include.net.'
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns3.dns-zoneparse-test.net.',
@@ -186,7 +186,7 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test-include2.net.'
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns3.dns-zoneparse-test.net.',
@@ -202,7 +202,7 @@ sub test_zone {
         [
             {
                 'priority' => '10',
-                'ttl'      => '1H',
+                'ttl'      => '43200',
                 'name'     => '@',
                 'class'    => 'IN',
                 'host'     => 'mail',
@@ -210,7 +210,7 @@ sub test_zone {
             },
             {
                 'priority' => '10',
-                'ttl'      => '1H',
+                'ttl'      => '43200',
                 'name'     => '@',
                 'class'    => 'IN',
                 'host'     => 'mail2',
@@ -218,7 +218,7 @@ sub test_zone {
             },
             {
                 'priority' => '10',
-                'ttl'      => '1H',
+                'ttl'      => '43200',
                 'name'     => '@',
                 'class'    => 'IN',
                 'host'     => 'mail2',
@@ -226,7 +226,7 @@ sub test_zone {
             },
             {
                 'priority' => '10',
-                'ttl'      => '1H',
+                'ttl'      => '43200',
                 'name'     => '@',
                 'class'    => 'IN',
                 'host'     => 'mail2',
@@ -240,28 +240,28 @@ sub test_zone {
         $zf->cname,
         [
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'ftp',
                 'class'  => 'IN',
                 'host'   => 'www',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'ftp',
                 'class'  => 'IN',
                 'host'   => 'www1',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'ftp',
                 'class'  => 'IN',
                 'host'   => 'www1',
                 'ORIGIN' => 'dns-zoneparse-test-include.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'ftp',
                 'class'  => 'IN',
                 'host'   => 'www1',

--- a/t/dns-zoneparse-origin-soa.t
+++ b/t/dns-zoneparse-origin-soa.t
@@ -66,7 +66,7 @@ sub test_zone {
                 'ORIGIN' => 'net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns1.dns-zoneparse-test.net.',

--- a/t/dns-zoneparse.t
+++ b/t/dns-zoneparse.t
@@ -76,35 +76,35 @@ sub test_zone {
         $zf->a,
         [
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => '127.0.0.1',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'localhost',
                 'class'  => 'IN',
                 'host'   => '127.0.0.1',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'mail',
                 'class'  => 'IN',
                 'host'   => '127.0.0.1',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'www',
                 'class'  => 'IN',
                 'host'   => '127.0.0.1',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'www',
                 'class'  => 'IN',
                 'host'   => '10.0.0.2',
@@ -118,21 +118,21 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'www',
                 'class'  => 'IN',
                 'host'   => '10.0.0.5',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'foo',
                 'class'  => 'IN',
                 'host'   => '10.0.0.6',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'mini',
                 'class'  => 'IN',
                 'host'   => '10.0.0.7',
@@ -153,7 +153,7 @@ sub test_zone {
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => '@',
                 'class'  => 'IN',
                 'host'   => 'ns1.dns-zoneparse-test.net.',
@@ -168,7 +168,7 @@ sub test_zone {
         [
             {
                 'priority' => '10',
-                'ttl'      => '1H',
+                'ttl'      => '43200',
                 'name'     => '@',
                 'class'    => 'IN',
                 'host'     => 'mail',
@@ -176,7 +176,7 @@ sub test_zone {
             },
             {
                 'priority' => '10',
-                'ttl'      => '1H',
+                'ttl'      => '43200',
                 'name'     => 'www',
                 'class'    => 'IN',
                 'host'     => '10.0.0.4',
@@ -190,14 +190,14 @@ sub test_zone {
         $zf->cname,
         [
             {
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'ftp',
                 'class'  => 'IN',
                 'host'   => 'www',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'name'   => '-=+!@#$%^&*`~://+-,[]{}|\\?~`\'";',
                 'class'  => 'IN',
                 'host'   => 'ns0.dns-zoneparse-test.net.',
@@ -212,49 +212,49 @@ sub test_zone {
         [
             {
                 'text'   => 'web server',
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'www',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
                 'text'   => 'This is a text message',
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'soup',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
                 'text'   => 'This is another text message',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'name'   => 'txta',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
                 'text'   => 'I\'ve"got\\back\\"slashes;!',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'name'   => 'txttest1',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
                 'text'   => 'embedded"quote',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'name'   => 'txttest2',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
                 'text'   => 'noquotes',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'name'   => 'txttest3',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
             {
                 'text'   => 'MORE (complicated) stuff -h343-',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'name'   => 'txttest4',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -268,7 +268,7 @@ sub test_zone {
         [
             {
                 'host'   => 'fe80::0260:83ff:fe7c:3a2a',
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'name'   => 'icarus',
                 'class'  => 'IN',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -283,7 +283,7 @@ sub test_zone {
             {
                 'name'   => 'txta',
                 'class'  => 'IN',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'mbox'   => 'mbox',
                 'text'   => 'sometext',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -298,7 +298,7 @@ sub test_zone {
             {
                 'name'     => 'srvtest1.a',
                 'class'    => 'IN',
-                'ttl'      => '1H',
+                'ttl'      => '86401',
                 'priority' => 11,
                 'weight'   => 22,
                 'port'     => 33,
@@ -308,7 +308,7 @@ sub test_zone {
             {
                 'name'     => 'srvtest2',
                 'class'    => 'IN',
-                'ttl'      => '1H',
+                'ttl'      => '86401',
                 'priority' => 11,
                 'weight'   => 22,
                 'port'     => 33,
@@ -324,7 +324,7 @@ sub test_zone {
         [
             {
                 'name'   => 'borrowed.from.rfc.1876.com.',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'class'  => 'IN',
                 'd1'     => '42',
                 'm1'     => '21',
@@ -342,7 +342,7 @@ sub test_zone {
             },
             {
                 'name'   => 'borrowed2.from.rfc.1876.com.',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'class'  => 'IN',
                 'd1'     => '42',
                 'm1'     => '21',
@@ -360,7 +360,7 @@ sub test_zone {
             },
             {
                 'name'   => 'borrowed3.from.rfc.1876.com.',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'class'  => 'IN',
                 'd1'     => '52',
                 'm1'     => '14',
@@ -378,7 +378,7 @@ sub test_zone {
             },
             {
                 'name'   => 'borrowed4.from.rfc.1876.com.',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'class'  => 'IN',
                 'd1'     => '32',
                 'm1'     => '7',
@@ -396,7 +396,7 @@ sub test_zone {
             },
             {
                 'name'   => 'borrowed5.from.rfc.1876.com.',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'class'  => 'IN',
                 'd1'     => '42',
                 'm1'     => '21',
@@ -414,7 +414,7 @@ sub test_zone {
             },
             {
                 'name'   => 'notborrowed.from.rfc.1876.com.',
-                'ttl'    => '1H',
+                'ttl'    => '86401',
                 'class'  => 'IN',
                 'd1'     => '32',
                 'm1'     => '7',
@@ -440,7 +440,7 @@ sub test_zone {
             {
                 'name'   => 'icarus',
                 'class'  => 'IN',
-                'ttl'    => '1H',
+                'ttl'    => '43200',
                 'cpu'    => 'server',
                 'os'     => 'freebsd',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -453,11 +453,10 @@ sub test_zone {
                 'os'     => 'freebsd',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
             },
-
             {
                 name     => 'commenttest0',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -465,7 +464,7 @@ sub test_zone {
             {
                 name     => 'commenttest1',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -473,7 +472,7 @@ sub test_zone {
             {
                 name     => 'commenttest2',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -481,7 +480,7 @@ sub test_zone {
             {
                 name     => 'commenttest3',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -489,7 +488,7 @@ sub test_zone {
             {
                 name     => 'commenttest4',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -497,7 +496,7 @@ sub test_zone {
             {
                 name     => 'commenttest5',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -505,7 +504,7 @@ sub test_zone {
             {
                 name     => 'commenttest6',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -513,7 +512,7 @@ sub test_zone {
             {
                 name     => 'commenttest7',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -521,7 +520,7 @@ sub test_zone {
             {
                 name     => 'commenttest8',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -529,7 +528,7 @@ sub test_zone {
             {
                 name     => 'commenttest9',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -537,7 +536,7 @@ sub test_zone {
             {
                 name     => 'commenttest10',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -545,7 +544,7 @@ sub test_zone {
             {
                 name     => 'commenttest11',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -553,7 +552,7 @@ sub test_zone {
             {
                 name     => 'commenttest12',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -561,7 +560,7 @@ sub test_zone {
             {
                 name     => 'commenttest13',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -569,7 +568,7 @@ sub test_zone {
             {
                 name     => 'commenttest14',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -577,7 +576,7 @@ sub test_zone {
             {
                 name     => 'commenttest15',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -585,7 +584,7 @@ sub test_zone {
             {
                 name     => 'commenttest16',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -593,7 +592,7 @@ sub test_zone {
             {
                 name     => 'commenttest17',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -601,7 +600,7 @@ sub test_zone {
             {
                 name     => 'commenttest18',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -609,7 +608,7 @@ sub test_zone {
             {
                 name     => 'commenttest19',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -617,7 +616,7 @@ sub test_zone {
             {
                 name     => 'commenttest20',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -625,7 +624,7 @@ sub test_zone {
             {
                 name     => 'commenttest21',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -633,7 +632,7 @@ sub test_zone {
             {
                 name     => 'commenttest22',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -641,7 +640,7 @@ sub test_zone {
             {
                 name     => 'commenttest23',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'test',
                 os       => 'tes;t2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -649,7 +648,7 @@ sub test_zone {
             {
                 name     => 'commenttest24',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -657,7 +656,7 @@ sub test_zone {
             {
                 name     => 'commenttest25',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -665,7 +664,7 @@ sub test_zone {
             {
                 name     => 'commenttest26',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -673,7 +672,7 @@ sub test_zone {
             {
                 name     => 'commenttest27',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -681,7 +680,7 @@ sub test_zone {
             {
                 name     => 'commenttest28',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -689,7 +688,7 @@ sub test_zone {
             {
                 name     => 'commenttest29',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -697,7 +696,7 @@ sub test_zone {
             {
                 name     => 'commenttest30',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -705,7 +704,7 @@ sub test_zone {
             {
                 name     => 'commenttest31',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'test2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -713,7 +712,7 @@ sub test_zone {
             {
                 name     => 'commenttest32',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'te;st2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -721,7 +720,7 @@ sub test_zone {
             {
                 name     => 'commenttest33',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'te;st2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -729,7 +728,7 @@ sub test_zone {
             {
                 name     => 'commenttest34',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'te;st2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -737,7 +736,7 @@ sub test_zone {
             {
                 name     => 'commenttest35',
                 class    => 'IN',
-                ttl      => '1H',
+                ttl      => '86401',
                 cpu      => 'te;st',
                 os       => 'te;st2',
                 'ORIGIN' => 'dns-zoneparse-test.net.',
@@ -752,7 +751,7 @@ sub test_zone {
         [
             {
                 'rhs' => '10.0.0.$',
-                'ttl' => '1H',
+                'ttl' => '43200',
                 'lhs' => 'www$',
                 'range' => '1-10/1',
                 'type' => 'A',


### PR DESCRIPTION
This pull request contains both the $INCLUDE parsing functionality and RFC 2308 $TTL complaince changes into the dns-zoneparse-perl repo (both of which are explained below).

$INCLUDE parsing

$INCLUDE directives are read and parsed before the main record parsing loop to enable the included records to be parsed in the same manner as all other records.

The domain and comment parameters are supported by this new functionality however the latter is not used in the code. The domain parameter sets the relative origin of the records that are included. If excluded, the origin of the including zone is used.

The behavior of the $INCLUDE directive is to include the records of the zone file specified at the position of the directive, meaning that if the first record in the included zone has a blank name it will inherit the name of the last named record, as expected in any zone.

Added new test 'dns-zoneparse-include.t' to test the inclusion of records from another zone but without impacting the primary test. The new test is mostly a clone of dns-zoneparse.t however testing of the parsing of previously parsed and outputted records is not performed as this returns the included records being returned in an order different than when parsed directly from file or variable.

The addition of the test also saw the addition of 2 new zones, 'include-test-zone.db' which contains the $INCLUDE directives and 'included-test-zone.db' which is included by the former zone and has slight alternations in the record name and or values to distinguish the records in the test.

RFC2308 $TTL compliance

The RFC above introduces the $TTL directive that when configured causes all RRs to have their TTL set to the $TTL value if not explicitly set. This overrides the behavior of records inheriting the TTL from the last record that had it explicitly set.

The $dns_dollar_ttl variable has been introduced to store the TTL value when set by the directive and used to set the TTL of records when one is not already defined by the record.

When the $TTL directive is not used, records will use the original behavior of inheriting the last explicitly set TTL value or using the SOA record's minimum TTL.

An additional test 'dns-zoneparse-dollar-ttl.t' has been added to prove that the original behavior works when the $TTL directive is not set. The master test 'dns-zoneparse.t' has been updated to reflect the parsed result when the $TTL directive is set.
